### PR TITLE
feat: only use 3 preset colors for demonstration

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -11,4 +11,4 @@ Neos:
           # `mode` can be one of "rgba", "hsla", "hex"
           mode: 'rgba'
           # Colors which are available for quick selection
-          presetColors: ['#D0021B', '#F5A623', '#F8E71C', '#8B572A', '#7ED321', '#417505', '#BD10E0', '#9013FE', '#4A90E2', '#50E3C2', '#B8E986', '#000000', '#4A4A4A', '#9B9B9B', '#FFFFFF']
+          presetColors: ['#D0021B', '#F5A623', '#F8E71C']


### PR DESCRIPTION
Fixes https://github.com/Sebobo/Shel.Neos.ColorPicker/issues/53
This makes it easier to use Shel.Neos.ColorPicker with less than 15 Preset Colors.